### PR TITLE
Enabled (get_)the_block() to work outside The Loop

### DIFF
--- a/assets/inc/functions.template-tags.php
+++ b/assets/inc/functions.template-tags.php
@@ -8,8 +8,8 @@
  *
  * @param string $name The name of the block
  */
-function the_block($name) {
-	echo get_the_block($name);
+function the_block($name,$post_id=null) {
+	echo get_the_block($name,$post_id);
 }
 
 /**
@@ -17,12 +17,15 @@ function the_block($name) {
  *
  * @param string $name The name of the block
  */
-function get_the_block($name) {
+function get_the_block($name,$post_id=null) {
 	if(!empty($name)) :
-		global $post;
-		mcb_register_block($post->ID,$name);
+		if(empty($post_id)) {
+			global $post;
+			$post_id = $post->ID;
+		}
+		mcb_register_block($post_id,$name);
 		
-		return apply_filters('the_content',get_post_meta($post->ID,'mcb-'.sanitize_title($name),true));
+		return apply_filters('the_content',get_post_meta($post_id,'mcb-'.sanitize_title($name),true));
 	endif;
 }
 


### PR DESCRIPTION
Hello,

I was helping someone in #wordpress on freenode yesterday, and they were using your plugin.

It would have been easier for them to get what they wanted done if they could have passed a post id to the_block().

I saw your code is on GitHub, so I thought I'd send you a patch to add that.

Thanks for sharing your software.
