### PR TITLE
Add 'htmlentities' argument to get_the_block() and the_block

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Additional options
 --------------
 	the_block($name,array(
 		'type' => 'one-liner',
-		'apply_filters' => false
+		'apply_filters' => false,
+		'htmlentities' => false
 	))
 - Won't display a WYSIWYG editor, but a plain one line text field (input type="text").
 - Won't apply filters
+- Won't apply htmlentities() when apply_filters = false.

--- a/assets/inc/functions.template-tags.php
+++ b/assets/inc/functions.template-tags.php
@@ -31,7 +31,8 @@ function get_the_block($name,$args=array()) {
 		
 		$defaults = array(
 			'type' => 'editor',
-			'apply_filters' => true
+			'apply_filters' => true,
+			'htmlentities' => true
 		);
 		$args = wp_parse_args($args, $defaults);
 		
@@ -39,8 +40,11 @@ function get_the_block($name,$args=array()) {
 		
 		$meta = get_post_meta($post->ID,'mcb-'.sanitize_title($name),true);
 		
-		if($args['apply_filters']) return apply_filters('the_content',$meta);
-		if($meta && count($meta) > 0) return htmlentities($meta,null,'UTF-8',false);
+		if($meta && count($meta) > 0) {
+			if($args['apply_filters']) return apply_filters('the_content',$meta);
+			if($args['htmlentities']) return htmlentities($meta,null,'UTF-8',false);
+			return $meta;
+		}
 	endif;
 	
 	return '';


### PR DESCRIPTION
- Used when you do not want to apply filters and do not want to apply htmlentities().
- Ignored when apply_filters is true.
- Also wrapped apply_filters with the check that $meta has a value.
- Warning: This bypasses any XSS protection.

``` php
get_the_block('Name of Block', array('apply_filters' => false, 'htmentities' => false);
```

Returns

```
<h1>Hello</h1>
```

Instead of

```
&lt;h1&gt;Hello&lt;/h1&gt;
```
