### PR TITLE
Fix for issue #56 :: added ENT_COMPAT to one-liner meta box value

### DIFF
--- a/assets/inc/class-mcb.php
+++ b/assets/inc/class-mcb.php
@@ -75,7 +75,7 @@ class MCB {
 				echo '<p><strong>' . $label . '</strong></p>';
 
 				if( 'one-liner' == $type )
-				  echo '<input type="text" name="' . $id . '" value="' . htmlentities( get_post_meta( $post->ID, '_mcb-' . $id, true ), null, 'UTF-8', false ) . '" />';
+				  echo '<input type="text" name="' . $id . '" value="' . htmlentities( get_post_meta( $post->ID, '_mcb-' . $id, true ), ENT_COMPAT, 'UTF-8', false ) . '" />';
 				else
 					wp_editor( get_post_meta( $post->ID, '_mcb-' . $id, true ), $id );
 			}


### PR DESCRIPTION
This fixes the issue by changing the `htmlentities()` flag argument to `ENT_COMPAT` instead of `NULL` on the one-liner postmeta box display. According to the php manual, `ENT_COMPAT` will _convert double-quotes and leave single-quotes alone_. This seems to be desired behavior, and allows for shortcodes and other quote-containing strings to be used properly in one-liner content blocks.
