### PR TITLE
Fix function declaration error in WP 5.0

### DIFF
--- a/assets/inc/template-tags.php
+++ b/assets/inc/template-tags.php
@@ -59,7 +59,7 @@ function get_the_block( $name, $args = array() ) {
  * @param string $name
  * @param array $args Optional. Additional arguments, see get_the_block for more information
  */
-function has_block( $name, $args = array() ) {
+function mcb_has_block( $name, $args = array() ) {
 	if( 0 < strlen( get_the_block( $name, $args ) ) ) 
 		return true;
 


### PR DESCRIPTION
The `has_block` function has already been declared in `wp-includes/blocks.php @81` in WP version 5 and above. This fixes the issues, but you may want to prefix other functions.